### PR TITLE
Task 7 add title model

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,5 +1,6 @@
 class Student < ActiveRecord::Base
-  attr_accessible :birth_date, :email, :first_name, :gender, :last_name, :middle_name, :title
+  attr_accessible :birth_date, :email, :first_name, :gender, :last_name, :middle_name, :title_id
+  belongs_to :title
 
   DEFAULT_PER_PAGE = 20
 

--- a/app/models/title.rb
+++ b/app/models/title.rb
@@ -1,0 +1,9 @@
+class Title < ActiveRecord::Base
+  attr_accessible :name
+
+  validates :name, presence: true, uniqueness: true
+
+  def to_s
+    self.name
+  end
+end

--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -14,8 +14,7 @@
       <% end %>
 
       <div class="form-group">
-        <%= f.label :title %><br />
-        <%= f.text_field :title, class: "form-control" %>
+        <%= f.collection_select(:title_id, Title.all, :id, :name, {}, { class: 'form-control' }) %>
       </div>
       <div class="form-group">
         <%= f.label :first_name %><br />

--- a/db/migrate/20210217230816_create_titles.rb
+++ b/db/migrate/20210217230816_create_titles.rb
@@ -1,0 +1,13 @@
+class CreateTitles < ActiveRecord::Migration
+  def change
+    rename_column :students, :title, :old_title
+
+    create_table :titles do |t|
+      t.string :name, null: false, unique: true
+    end
+
+    change_table :students do |t|
+      t.references :title
+    end
+  end
+end

--- a/db/migrate/20210217233058_migrate_title_data.rb
+++ b/db/migrate/20210217233058_migrate_title_data.rb
@@ -1,0 +1,28 @@
+class MigrateTitleData < ActiveRecord::Migration
+  def change
+    # cache of titles
+    titles = {}
+
+    # pull all unique titles out of the student table and insert them
+    # into the database. Ignore empty titles.
+    Student.uniq.pluck(:old_title).each do |title|
+      unless title.in? [nil, ""]
+        t = Title.create({ name: title })
+        titles[title] = t.id
+      end
+    end
+
+    # go through the student table in batches assigning relevant cached title
+    # id to the title_id foreign key attribute in the student table, if the student
+    # has a title in the cache.
+    Student.find_in_batches do |batch|
+      Student.transaction do
+        batch.each do |student|
+          if titles.key?(student.old_title)
+            Student.transaction { student.update_attribute(:title_id, titles[student.old_title]) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210217235826_remove_old_title_id_from_students.rb
+++ b/db/migrate/20210217235826_remove_old_title_id_from_students.rb
@@ -1,0 +1,5 @@
+class RemoveOldTitleIdFromStudents < ActiveRecord::Migration
+  def change
+    remove_column :students, :old_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,9 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20210128004238) do
+ActiveRecord::Schema.define(:version => 20210217235826) do
 
   create_table "students", :force => true do |t|
-    t.string   "title"
     t.string   "first_name"
     t.string   "middle_name"
     t.string   "last_name"
@@ -23,6 +22,11 @@ ActiveRecord::Schema.define(:version => 20210128004238) do
     t.string   "gender"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.integer  "title_id"
+  end
+
+  create_table "titles", :force => true do |t|
+    t.string "name", :null => false
   end
 
 end

--- a/spec/decorators/student_decorator_spec.rb
+++ b/spec/decorators/student_decorator_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe StudentDecorator do
-  subject { build(:student, title: "Mr.", first_name: "John", middle_name: "Adam", last_name: "Smith", birth_date: "2000-01-01").decorate }
+  let(:title) { build(:title, name: "Mr.") }
+  subject { build(:student, title: title, first_name: "John", middle_name: "Adam", last_name: "Smith", birth_date: "2000-01-01").decorate }
 
   it { is_expected.to have_attributes(full_name: "Mr. John Adam Smith") }
   it { is_expected.to have_attributes(born: "2000-01-01") }

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :student do
-    title { Faker::Name.prefix}
+    association :title
     first_name { Faker::Name.first_name }
     middle_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }

--- a/spec/factories/titles.rb
+++ b/spec/factories/titles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :title do
+    name { Faker::Name.prefix }
+  end
+end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Student, :type => :model do
-  subject { build(:student, title: "Mr.", first_name: "John", middle_name: "Adam", last_name: "Smith", email: "tester@example.com", gender: "Male", birth_date: "2000-01-01") }
+  let(:title) { build(:title, name: "Mr.") }
+  subject { build(:student, title: title, first_name: "John", middle_name: "Adam", last_name: "Smith", email: "tester@example.com", gender: "Male", birth_date: "2000-01-01") }
 
   it { is_expected.to be_valid }
-  it { is_expected.to have_attributes(title: "Mr.") }
+  it { is_expected.to have_attributes(title: title) }
   it { is_expected.to have_attributes(first_name: "John") }
   it { is_expected.to have_attributes(middle_name: "Adam") }
   it { is_expected.to have_attributes(last_name: "Smith") }

--- a/spec/models/title_spec.rb
+++ b/spec/models/title_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Title, :type => :model do
+  subject { build(:title, name: "Mr.") }
+
+  it { is_expected.to have_attributes(name: "Mr.") }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+end


### PR DESCRIPTION
## Description
Implements a Title model, which is associated with the Student model via a belongs_to relationship. Migration focuses on making necessary schema changes first then in a separate migration file migrates the data from the old title attribute to the new table. To reduce the chances of error, the titles are inferred from the student table. 

Some effort was made to reduce the chance of locking the entire students table during the second phase of the migration however I believe there's still a whole table lock during the transaction. If a reviewer could please provide some feedback on how to prevent a table lock in Rails 3.2 that'd be very much appreciated.

## Breakdown of Commits
Commit 1 : 2e7de1c
- I setup the Title model using `rails g model title name:string`
- Added some basic validations and opted to override the to string method so that the student model would function more or less the same way when the `title` attribute was called.

Commit 2 : 28906ae
- Followed [Matt Duszynskis practice](https://www.youtube.com/watch?v=KROgsx5zosA) of separating schema changes from data migration.
- Performed in the migration in three steps:
   1. Renamed the title attr in the students table (in retrospect I don't think I needed to do that), created the titles table & added title foreign key to students table.
   2. Populated the titles table with unique titles from the old titles field. Using a cache of titles the script assigns the id of the title to the student based on the contents of the old_title attr
   3. Finally removes the old_title attr.

Commit 3 : 77bbdbf
- Ran the migration updating the schema.rb file.

Commit 4 : 4454c84
- All my specs were failing at this point so I modified the specs, and the student to account for the association.
- Added a html select field to the edit form.

#### TODO Checklist
* [x] Create a Title model and populate it, add relation Student belongs_to Title.
* [x] assume this app is in production and there is data in the Students.title attr.
* [x] migrate data from Student.title to the Title model.
* [x] can we remove the Student.title attr now? (yes)
* [x] for the Student Edit page, add a dropdown to the title input box that will now pull from the Title model.

#### Screenshot (If applicable)
