### PR TITLE
Task 13: Create Institute index with pagination

### DIFF
--- a/app/controllers/institutes_controller.rb
+++ b/app/controllers/institutes_controller.rb
@@ -1,0 +1,5 @@
+class InstitutesController < ApplicationController
+  def index
+    @institutes = Institute.paginate(page: params[:page], per_page: DEFAULT_PER_PAGE)
+  end
+end

--- a/app/views/institutes/index.html.haml
+++ b/app/views/institutes/index.html.haml
@@ -1,0 +1,1 @@
+%h1 Institutes

--- a/app/views/institutes/index.html.haml
+++ b/app/views/institutes/index.html.haml
@@ -1,1 +1,10 @@
-%h1 Institutes
+%h1 🏫 Institutes
+
+%table.table
+  %tr
+    %th{scope: "col"} Name
+  - @institutes.each do |institute|
+    %tr
+      %td= institute.name
+
+.d-flex.justify-content-center= will_paginate @institutes

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -13,3 +13,5 @@
           = link_to 'Students', students_path
         %li{ class: current_page?(courses_path) ? "active": nil }
           = link_to 'Courses', courses_path, class: current_page?(courses_path) ? "active" : nil
+        %li{ class: current_page?(institutes_path) ? "active": nil }
+          = link_to 'Institutes', institutes_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 MySMS::Application.routes.draw do
   resources :students, only: [:index, :show, :edit, :update, :destroy]
   resources :courses, only: [:index, :show, :edit, :update, :destroy]
+  resources :institutes, only: [:index]
 
   # The priority is based upon order of creation:
   # first created -> highest priority.

--- a/spec/controllers/institutes_controller_spec.rb
+++ b/spec/controllers/institutes_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe InstituteController, type: :controller do
+RSpec.describe InstitutesController, type: :controller do
   let!(:institute) { create(:institute) }
 
   describe "GET #index" do
@@ -8,10 +8,10 @@ RSpec.describe InstituteController, type: :controller do
 
     it "populates an array of institutes" do
       subject
-      expect(assigns(:institute)).to eq([institute])
+      expect(assigns(:institutes)).to eq([institute])
     end
 
     it { is_expected.to have_http_status(:success) }
-    it { is_expected.to render_template("courses/index") }
+    it { is_expected.to render_template("institutes/index") }
   end
 end

--- a/spec/controllers/institutes_controller_spec.rb
+++ b/spec/controllers/institutes_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe InstituteController, type: :controller do
+  let!(:institute) { create(:institute) }
+
+  describe "GET #index" do
+    subject { get :index }
+
+    it "populates an array of institutes" do
+      subject
+      expect(assigns(:institute)).to eq([institute])
+    end
+
+    it { is_expected.to have_http_status(:success) }
+    it { is_expected.to render_template("courses/index") }
+  end
+end

--- a/spec/controllers/institutes_controller_spec.rb
+++ b/spec/controllers/institutes_controller_spec.rb
@@ -13,5 +13,14 @@ RSpec.describe InstitutesController, type: :controller do
 
     it { is_expected.to have_http_status(:success) }
     it { is_expected.to render_template("institutes/index") }
+
+    context "number of institutes exceeds the default page size" do
+      let!(:institutes) { create_list(:institute, DEFAULT_PER_PAGE + 1) }
+
+      it "returns the default page size of values at most" do
+        subject
+        expect(assigns(:institutes).length).to eq(DEFAULT_PER_PAGE)
+      end
+    end
   end
 end

--- a/spec/factories/institutes.rb
+++ b/spec/factories/institutes.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :institute do
-    name { Faker::Educator.university }
+    sequence(:name) { |n| Faker::Educator.university + "-#{n}" }
   end
 end


### PR DESCRIPTION
## Description
The purpose of this PR is to add an index page for the Institute resource. There should exist a page which displays a list of all Institutes & a pagination menu.

## Breakdown of Commits
Commit 1: 6fe7c53
- Created RSpec tests that the index action must satisfy.

Commit 2: f4b5ad2
- Added an Institute resource in the routes.rb file, whitelisting the index action.
- Added the institutes index action, passing a paginated institutes object to the view.
- Corrected a mistake I made in the spec, I should really make a snippet generator instead of copying and pasting between similar specs.

Commit 3: f055a15
- Populated the view with a table which displays the Institutes name.
- Added an Institutes option to the navigation bar.

#### TODO Checklist
* [x] Create an Institute List Page displaying name, with pagination
