### PR TITLE
Task 15: Create association between Institute & Courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,7 +2,7 @@ class CoursesController < ApplicationController
   before_filter :load_course, except: [:index]
 
   def index
-    @courses = Course.paginate(page: params[:page], per_page: DEFAULT_PER_PAGE).decorate
+    @courses = Course.includes(:institute).paginate(page: params[:page], per_page: DEFAULT_PER_PAGE).decorate
   end
 
   def show

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,7 +2,7 @@ class CoursesController < ApplicationController
   before_filter :load_course, except: [:index]
 
   def index
-    @courses = Course.includes(:institute).paginate(page: params[:page], per_page: DEFAULT_PER_PAGE).decorate
+    @courses = Course.for_index(page: params[:page], per_page: DEFAULT_PER_PAGE).decorate
   end
 
   def show

--- a/app/controllers/institutes_controller.rb
+++ b/app/controllers/institutes_controller.rb
@@ -1,11 +1,12 @@
 class InstitutesController < ApplicationController
-  before_filter :load_institute, except: [:index]
+  before_filter :load_institute, except: [:index, :show]
 
   def index
     @institutes = Institute.paginate(page: params[:page], per_page: DEFAULT_PER_PAGE)
   end
 
   def show
+    @institute = Institute.includes(:courses).find(params[:id])
   end
 
   def edit

--- a/app/controllers/institutes_controller.rb
+++ b/app/controllers/institutes_controller.rb
@@ -1,12 +1,11 @@
 class InstitutesController < ApplicationController
-  before_filter :load_institute, except: [:index, :show]
+  before_filter :load_institute, except: [:index]
 
   def index
     @institutes = Institute.paginate(page: params[:page], per_page: DEFAULT_PER_PAGE)
   end
 
   def show
-    @institute = Institute.includes(:courses).find(params[:id])
   end
 
   def edit

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -1,5 +1,6 @@
 class CourseDecorator < Draper::Decorator
   delegate_all
+  decorates_association :institute
 
   def commence
     l object.start_date, format: :default

--- a/app/decorators/institute_decorator.rb
+++ b/app/decorators/institute_decorator.rb
@@ -1,0 +1,7 @@
+class InstituteDecorator < Draper::Decorator
+  delegate_all
+
+  def to_s
+    name
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,10 @@ class Course < ActiveRecord::Base
 
   validate :ends_after_starts
 
+  def self.for_index(page:, per_page:)
+    includes(:institute).paginate(page: page, per_page: per_page)
+  end
+
   private
 
   def ends_after_starts

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,8 @@
 class Course < ActiveRecord::Base
   attr_accessible :allocation, :description, :end_date, :name, :number_of_semesters, :start_date
 
+  belongs_to :institute
+
   validates :name, presence: true, length: { maximum: 255 }
   validates :allocation, presence: true, numericality: { greater_than: 0 }
   validates :number_of_semesters, numericality: { greater_than: 0 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,5 @@
 class Course < ActiveRecord::Base
-  attr_accessible :allocation, :description, :end_date, :name, :number_of_semesters, :start_date
+  attr_accessible :allocation, :description, :end_date, :name, :number_of_semesters, :start_date, :institute_id
 
   belongs_to :institute
 

--- a/app/models/institute.rb
+++ b/app/models/institute.rb
@@ -1,6 +1,8 @@
 class Institute < ActiveRecord::Base
   attr_accessible :name
 
+  has_many :courses
+
   validates :name, presence: true, length: { maximum: 255 },
             uniqueness: true
 end

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -32,5 +32,7 @@
         = f.label :end_date
         %br/
         = f.date_select :end_date
+      .form-group
+        = f.collection_select(:institute_id, Institute.all, :id, :name, {}, { class: 'form-control' })
       .actions
         = f.submit 'Save', class: "d-inline-block btn btn-success"

--- a/app/views/courses/index.html.haml
+++ b/app/views/courses/index.html.haml
@@ -7,6 +7,7 @@
     %th{scope: "col"} Allocation
     %th{scope: "col"} Start Date
     %th{scope: "col"} End Date
+    %th{scope: "col"} Institute
     %th{scope: "col"}
   - @courses.each do |course|
     %tr
@@ -15,6 +16,7 @@
       %td= course.allocation
       %td= course.commence
       %td= course.conclude
+      %td= course.institute
       %td
         = link_to course_path(course), class: "btn btn-default btn-xs", 'aria-label': 'Show' do
           %span.glyphicon.glyphicon-eye-open{ 'aria-hidden': 'true' }

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -7,6 +7,9 @@
   %strong Description:
   = @course.description
 %p
+  %strong Institute:
+  = @course.institute.name
+%p
   %strong Semesters:
   = @course.number_of_semesters
 %p

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -8,7 +8,7 @@
   = @course.description
 %p
   %strong Institute:
-  = @course.institute.name
+  = @course.institute
 %p
   %strong Semesters:
   = @course.number_of_semesters

--- a/app/views/institutes/show.html.haml
+++ b/app/views/institutes/show.html.haml
@@ -3,5 +3,12 @@
 %p
   %strong Name:
   = @institute.name
+%p
+  %strong Courses:
+  %ul
+    - @institute.courses.each do |course|
+      %li
+        = link_to "[#{course.id}] #{course.name}", course_path(course)
+
 
 = link_to 'Back', institutes_path, class: 'btn btn-default'

--- a/db/migrate/20210303025206_add_institution_to_course.rb
+++ b/db/migrate/20210303025206_add_institution_to_course.rb
@@ -1,0 +1,13 @@
+class AddInstitutionToCourse < ActiveRecord::Migration
+  def up
+    change_table :courses do |t|
+      t.references :institute
+    end
+  end
+
+  def down
+    change_table :courses do |t|
+      t.remove_references :institute
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20210301034134) do
+ActiveRecord::Schema.define(:version => 20210303025206) do
 
   create_table "courses", :force => true do |t|
     t.string   "name",                :null => false
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(:version => 20210301034134) do
     t.integer  "allocation",          :null => false
     t.datetime "created_at",          :null => false
     t.datetime "updated_at",          :null => false
+    t.integer  "institute_id"
   end
 
   create_table "institutes", :force => true do |t|

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :course do
+    association :institute
     name { Faker::Educator.subject }
     description { Faker::Lorem.paragraph(sentence_count: 2) }
     number_of_semesters { Faker::Number.non_zero_digit }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Course, :type => :model do
-  subject { build(:course) }
+  let!(:institute) { create :institute }
+  subject { build(:course, institute: institute) }
+
+  it { is_expected.to belong_to(:institute) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:allocation) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Course, :type => :model do
-  let!(:institute) { create :institute }
-  subject { build(:course, institute: institute) }
+  subject { build(:course) }
 
   it { is_expected.to belong_to(:institute) }
 

--- a/spec/models/institute_spec.rb
+++ b/spec/models/institute_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Institute, :type => :model do
   subject { build(:institute) }
 
+  it { is_expected.to have_many(:courses) }
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_length_of(:name).is_at_most(255) }
   it { is_expected.to validate_uniqueness_of(:name) }


### PR DESCRIPTION
## Description
This PR is responsible for defining a relationship between Institutes & Courses. In summary, an Institute has a has_many relationship with courses, the latter having a belongs_to relationship with the former. This PR makes better use of Eager loading to reduce the number of queries on the DB. Additionally, this PR is the first to declare RSpec tests for associations between models.

## Breakdown of Commits
Commit 1: 9094a8e
- Created a migration file for adding/removing the institute_id to the courses table.
- Also adds the association calls in the respective model files.

Commit 2: 8645ab8
- Added an Institute select form option on the Course edit view.

Commit 3: 7c38278
- Added RSpec tests for both the Institute & Course model specs.

Commit 4: 253ad16
- Added the assigned institute name to both the Course index & show view.

Commit 5: 6a9d4fc
- Added a list of assigned courses to the Institute show view.

#### TODO Checklist
* [x] Add relations, Institute has_many Courses.   A Course belongs_to Institute.
* [x] Update Course Edit Page, add a new input field dropdown listing available Institutes 
* [x] Update Course List page to display Institute name 
* [x] Update the Institute List page, displaying all courses within an institute where the course name is the link to the Course Show page